### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -65,9 +65,9 @@ jobs:
         id: styles-ref
         run: |
           if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            echo "ref=refs/pull/${{ github.event.pull_request.number }}/head" >> $GITHUB_OUTPUT
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/head" >> "$GITHUB_OUTPUT"
           else
-            echo "ref=gh-pages" >> $GITHUB_OUTPUT
+            echo "ref=gh-pages" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Sync lesson with carpentries/styles
@@ -85,7 +85,7 @@ jobs:
         id: check-rmd
         working-directory: lesson
         run: |
-          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> $GITHUB_OUTPUT
+          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> "$GITHUB_OUTPUT"
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -65,9 +65,9 @@ jobs:
         id: styles-ref
         run: |
           if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            echo "::set-output name=ref::refs/pull/${{ github.event.pull_request.number }}/head"
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/head" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=ref::gh-pages"
+            echo "ref=gh-pages" >> $GITHUB_OUTPUT
           fi
 
       - name: Sync lesson with carpentries/styles
@@ -85,7 +85,7 @@ jobs:
         id: check-rmd
         working-directory: lesson
         run: |
-          echo "::set-output name=count::$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})"
+          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> $GITHUB_OUTPUT
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Look for R-markdown files
         id: check-rmd
         run: |
-          echo "::set-output name=count::$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})"
+          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> $GITHUB_OUTPUT
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Look for R-markdown files
         id: check-rmd
         run: |
-          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> $GITHUB_OUTPUT
+          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> "$GITHUB_OUTPUT"
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


